### PR TITLE
docs: clarify snapshot profile semantics

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -168,3 +168,19 @@ Use case:
 5. Save the state as a snapshot profile.
 
 This is a good way to discover new profiles through actual usage instead of creating them all in settings first.
+
+What the snapshot keeps:
+
+- the exact enabled sources from that preview run
+- the preview order of those sources
+- the current template block toggles
+- the selected output target and output format
+
+What the snapshot does not keep dynamically:
+
+- future query results from the original profile
+- future backlink or folder expansion from the original profile
+- later edits to the original profile configuration
+
+In practice, think of a snapshot profile as "freeze this successful preview into
+a reusable profile" rather than "save a shortcut back to the original profile."

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -124,6 +124,45 @@ You can use it to:
 
 This is the fastest way to tune a profile before baking the settings in permanently.
 
+## Snapshot Profiles
+
+Snapshot profiles are created from the current preview state, not from a live
+"keep following whatever the original profile would do" link.
+
+When you save a snapshot profile, Promptfire preserves:
+
+- the currently enabled sources
+- the manual source order from the preview
+- the enabled and disabled template blocks
+- the selected output target
+- the selected output format
+
+It also converts the included preview sources into explicit `file` sources that
+point at the concrete note paths used in that preview run.
+
+That means a snapshot profile is useful when you want to keep a successful
+prompt build as a reusable starting point.
+
+It also means a snapshot stops tracking some dynamic behavior from the original
+profile. For example:
+
+- query-based or backlink-based source discovery is flattened into the specific
+  notes that were included when the snapshot was saved
+- source labels come from the included notes in that saved run
+- later changes to the original profile do not automatically flow into the
+  snapshot profile
+
+In short:
+
+- preview changes are temporary until you save them
+- a snapshot profile turns the current preview result into a reusable, fixed
+  profile
+- the snapshot is independent from the original profile after it is saved
+
+Use snapshot profiles when the current preview state is exactly the workflow you
+want to reuse later. Do not use them when you want to keep benefiting from
+dynamic source discovery in the original profile.
+
 ## When To Use Budgets
 
 Budgets matter when your vault contains too much context.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -129,7 +129,7 @@ This is the fastest way to tune a profile before baking the settings in permanen
 Snapshot profiles are created from the current preview state, not from a live
 "keep following whatever the original profile would do" link.
 
-When you save a snapshot profile, Promptfire preserves:
+When you save a snapshot profile, `Promptfire` preserves:
 
 - the currently enabled sources
 - the manual source order from the preview
@@ -137,7 +137,7 @@ When you save a snapshot profile, Promptfire preserves:
 - the selected output target
 - the selected output format
 
-It also converts the included preview sources into explicit `file` sources that
+It also converts the enabled preview sources into explicit `file` sources that
 point at the concrete note paths used in that preview run.
 
 That means a snapshot profile is useful when you want to keep a successful


### PR DESCRIPTION
## Summary
- explain what snapshot profiles preserve from the preview state
- clarify that snapshot profiles flatten dynamic discovery into explicit file sources
- distinguish temporary preview tweaks from reusable saved profile state

## Why
Issue #12 asks for clearer documentation around snapshot-profile semantics so users understand what is frozen and what stops tracking dynamically after saving a snapshot.

## Validation
- `npm run build`

Closes #12.
