### PR TITLE
[codex] align release docs and enforce release checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,12 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    env:
+      RELEASE_ASSETS: |
+        manifest.json
+        main.js
+        styles.css
+        versions.json
 
     steps:
       - uses: actions/checkout@v4
@@ -23,11 +29,11 @@ jobs:
 
       - run: npm ci
       - run: npm run build
+      - name: Verify release metadata and assets
+        run: node verify-release.mjs --require-tag
+        env:
+          PROMPTFIRE_RELEASE_ASSETS: ${{ env.RELEASE_ASSETS }}
 
       - uses: softprops/action-gh-release@v2
         with:
-          files: |
-            manifest.json
-            main.js
-            styles.css
-            versions.json
+          files: ${{ env.RELEASE_ASSETS }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to `Promptfire` will be documented in this file.
 
+## 1.0.0 - 2026-04-06
+
+- First stable release of `Promptfire`.
+- Added deterministic prompt compilation from notes, folders, outgoing links,
+  backlinks, and search results.
+- Added configurable extraction, ordering, budgeting, and output formatting per
+  workflow.
+- Added output targets for clipboard, notes, scratchpads, and deep links.
+- Published the standard Obsidian release assets: `manifest.json`, `main.js`,
+  `styles.css`, and `versions.json`.
+
 ## 0.1.0 - 2026-04-01
 
 - Initial public release of `Promptfire` for Obsidian.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -17,70 +17,94 @@ This file documents the release workflow for `Promptfire`.
 - [versions.json](versions.json)
 - [CHANGELOG.md](CHANGELOG.md)
 - [docs/releases/](docs/releases/)
+- [.github/workflows/release.yml](.github/workflows/release.yml)
+
+## Canonical Release Outputs
+
+The current `1.x` GitHub release workflow publishes these flat assets:
+
+- `manifest.json`
+- `main.js`
+- `styles.css`
+- `versions.json`
+
+The canonical in-repo release notes are:
+
+- `CHANGELOG.md` for the short versioned summary
+- `docs/releases/<version>.md` for the detailed historical note
+- `docs/releases/<version>-body.md` for the GitHub release page body text
+
+The current workflow does not build or upload a ZIP archive.
 
 ## Release Checklist
 
-1. Update the version in `package.json`.
-2. Run:
+1. Update the version metadata.
 
-```bash
-npm version <version> --no-git-tag-version
-npm run version
-```
+   - update `package.json`
+   - run `npm run version` to sync `manifest.json` and `versions.json`
 
-3. Update release notes:
+   Or use:
 
-- add a new changelog section in `CHANGELOG.md`
-- add a detailed release note in `docs/releases/<version>.md`
-- add a Git release body in `docs/releases/<version>-body.md`
+   ```bash
+   npm version <version> --no-git-tag-version
+   npm run version
+   ```
 
-4. Build and verify:
+2. Update release notes:
 
-```bash
-npm install
-npm run build
-```
+   - add a new changelog section in `CHANGELOG.md`
+   - add a detailed release note in `docs/releases/<version>.md`
+   - add the GitHub release body text in `docs/releases/<version>-body.md`
 
-5. Copy the plugin into a vault for a real check:
+3. Build and verify:
 
-```bash
-cp main.js manifest.json styles.css <vault>/.obsidian/plugins/promptfire/
-```
+   ```bash
+   npm install
+   npm run build
+   PROMPTFIRE_RELEASE_TAG=v<version> npm run verify:release
+   ```
 
-6. Create the upload artifact:
+4. Copy the plugin into a vault for a real check:
 
-```bash
-mkdir -p dist
-zip -j dist/promptfire-<version>.zip manifest.json main.js styles.css
-sha256sum dist/promptfire-<version>.zip > dist/SHA256SUMS.txt
-```
+   ```bash
+   cp main.js manifest.json styles.css <vault>/.obsidian/plugins/promptfire/
+   ```
 
-7. Commit the release:
+5. Commit the release:
 
-```bash
-git add .
-git commit -m "Prepare <version> release"
-```
+   ```bash
+   git add .
+   git commit -m "Prepare <version> release"
+   ```
 
-8. Create the tag:
+6. Create the annotated tag:
 
-```bash
-git tag -a v<version> -m "Promptfire <version>"
-```
+   ```bash
+   git tag -a v<version> -m "Promptfire <version>"
+   ```
 
-9. Push branch and tag:
+7. Push the release commit and tag to the GitHub-hosted remote.
 
-```bash
-git push origin main
-git push origin v<version>
-```
+   If your GitHub remote is named `origin`, this is:
 
-10. Create the Git release page entry:
+   ```bash
+   git push origin main
+   git push origin v<version>
+   ```
 
-- tag: `v<version>`
-- title: `Promptfire <version>`
-- body: use `docs/releases/<version>-body.md`
-- asset: upload `dist/promptfire-<version>.zip`
+   If your GitHub remote has another name, replace `origin` with that remote.
+
+8. Wait for `.github/workflows/release.yml` to publish the GitHub release.
+
+9. Update the GitHub release body if needed.
+
+   - tag: `v<version>`
+   - title: `Promptfire <version>`
+   - body: use `docs/releases/<version>-body.md`
+
+   The current workflow publishes the assets automatically. The body text
+   remains a manual follow-up unless the workflow is extended to read the body
+   file.
 
 ## Verification Checklist
 
@@ -90,9 +114,11 @@ git push origin v<version>
 - Preview opens and recompiles
 - Default output target executes successfully
 - Vault config reload still works
+- GitHub release includes `manifest.json`, `main.js`, `styles.css`, and
+  `versions.json`
 
 ## Notes
 
-- `dist/` is intentionally ignored and should not be committed
-- The release body file is meant for copy/paste into the Git hosting UI
-- The detailed release note file is meant to stay in-repo as historical documentation
+- The tag push is what triggers the GitHub release workflow
+- The release body file is the canonical source for the release page text
+- The detailed release note file stays in-repo as historical documentation

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,6 +22,8 @@ This is the main documentation index for `Promptfire`.
 
 - [RELEASE.md](../RELEASE.md)
 - [CHANGELOG.md](../CHANGELOG.md)
+- [docs/releases/1.0.0.md](releases/1.0.0.md)
+- [docs/releases/1.0.0-body.md](releases/1.0.0-body.md)
 - [docs/releases/0.1.0.md](releases/0.1.0.md)
 - [docs/releases/0.1.0-body.md](releases/0.1.0-body.md)
 

--- a/docs/releases/1.0.0-body.md
+++ b/docs/releases/1.0.0-body.md
@@ -1,0 +1,23 @@
+# Promptfire 1.0.0
+
+First stable release of `Promptfire`, a structured prompt-compilation plugin
+for Obsidian AI workflows.
+
+## Highlights
+
+- Build deterministic prompts from notes, folders, links, backlinks, and
+  search results
+- Control extraction, ordering, budgets, and output format for each workflow
+- Export compiled context to the clipboard, notes, scratchpads, and deep links
+
+## Included Release Assets
+
+- `manifest.json`
+- `main.js`
+- `styles.css`
+- `versions.json`
+
+## Notes
+
+- Minimum supported Obsidian version: `1.5.0`
+- Current plugin version: `1.0.0`

--- a/docs/releases/1.0.0.md
+++ b/docs/releases/1.0.0.md
@@ -1,0 +1,51 @@
+# Promptfire 1.0.0
+
+First stable release of `Promptfire`.
+
+## Release Summary
+
+`Promptfire` turns an Obsidian vault into a controllable context compiler for
+external AI tools. The `1.0.0` release establishes the stable GitHub release
+shape for the plugin: flat Obsidian assets, version alignment across metadata
+files, and release notes tracked in-repo.
+
+## Included In 1.0.0
+
+- Profile-based prompt compilation
+- Source definitions for active notes, files, folders, outgoing links,
+  backlinks, and search queries
+- Section extractors for full note, frontmatter only, body only,
+  heading-filtered sections, and code blocks
+- Regex include and exclude filters per source
+- Per-source priority and character budgets
+- Per-block budgets and a global output budget
+- Output targets for clipboard, new note, append to note, append to active
+  note, scratchpad note, and deep links
+- Output formats for Markdown, XML, and JSON
+- Interactive preview controls for enabling sources, reordering sources,
+  toggling blocks, recompiling, and saving snapshot profiles
+- Vault-native configuration through `.promptfire.json`
+
+## Published Assets
+
+The `1.0.0` GitHub release publishes:
+
+- `manifest.json`
+- `main.js`
+- `styles.css`
+- `versions.json`
+
+## Technical Verification
+
+The `1.0.0` release has been verified with:
+
+- successful TypeScript and bundle build via `npm run build`
+- generated plugin assets in `main.js`, `manifest.json`, `styles.css`, and
+  `versions.json`
+- installation into the local test vault at `~/notes/.obsidian/plugins/promptfire`
+
+## Notes
+
+- `docs/releases/1.0.0-body.md` is the canonical source for the GitHub release
+  page text
+- `CHANGELOG.md` provides the shorter versioned summary

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "node esbuild.config.mjs",
     "build": "tsc --noEmit --skipLibCheck && node esbuild.config.mjs production",
+    "verify:release": "node verify-release.mjs",
     "version": "node version-bump.mjs && git add manifest.json versions.json"
   },
   "keywords": [

--- a/verify-release.mjs
+++ b/verify-release.mjs
@@ -1,0 +1,94 @@
+import { readFileSync, statSync } from "node:fs";
+
+const DEFAULT_ASSETS = [
+  "manifest.json",
+  "main.js",
+  "styles.css",
+  "versions.json",
+];
+
+function parseArgs(argv) {
+  return new Set(argv.slice(2));
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function resolveReleaseTag() {
+  if (process.env.PROMPTFIRE_RELEASE_TAG) {
+    return process.env.PROMPTFIRE_RELEASE_TAG;
+  }
+
+  if (process.env.GITHUB_REF_TYPE === "tag" && process.env.GITHUB_REF_NAME) {
+    return process.env.GITHUB_REF_NAME;
+  }
+
+  if (process.env.GITHUB_REF?.startsWith("refs/tags/")) {
+    return process.env.GITHUB_REF.slice("refs/tags/".length);
+  }
+
+  return "";
+}
+
+function resolveExpectedAssets() {
+  const configuredAssets = process.env.PROMPTFIRE_RELEASE_ASSETS
+    ?.split(/\r?\n/g)
+    .map((asset) => asset.trim())
+    .filter(Boolean);
+
+  return configuredAssets?.length ? configuredAssets : DEFAULT_ASSETS;
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function verifyMetadata({ requireTag }) {
+  const pkg = readJson("package.json");
+  const manifest = readJson("manifest.json");
+  const versions = readJson("versions.json");
+  const releaseTag = resolveReleaseTag();
+
+  assert(pkg.version, "package.json is missing a version.");
+  assert(manifest.version === pkg.version, `manifest.json version ${manifest.version} does not match package.json version ${pkg.version}.`);
+  assert(
+    typeof versions[pkg.version] === "string" && versions[pkg.version] === manifest.minAppVersion,
+    `versions.json entry for ${pkg.version} must exist and match manifest minAppVersion ${manifest.minAppVersion}.`,
+  );
+
+  if (requireTag) {
+    assert(releaseTag, "Release verification requires a tag ref such as v1.0.0.");
+  }
+
+  if (releaseTag) {
+    assert(releaseTag === `v${pkg.version}`, `Git tag ${releaseTag} does not match package.json version v${pkg.version}.`);
+  }
+
+  return { version: pkg.version, releaseTag };
+}
+
+function verifyAssets(assets) {
+  for (const asset of assets) {
+    const stat = statSync(asset, { throwIfNoEntry: false });
+    assert(stat?.isFile(), `Expected release asset ${asset} is missing.`);
+    assert(stat.size > 0, `Expected release asset ${asset} is empty.`);
+  }
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+  const requireTag = args.has("--require-tag");
+  const assets = resolveExpectedAssets();
+  const { version, releaseTag } = verifyMetadata({ requireTag });
+
+  verifyAssets(assets);
+
+  const tagSummary = releaseTag ? ` for ${releaseTag}` : "";
+  console.log(`Release verification passed for ${version}${tagSummary}.`);
+  console.log(`Verified assets: ${assets.join(", ")}`);
+}
+
+main();


### PR DESCRIPTION
## Summary
- align `CHANGELOG.md`, `RELEASE.md`, and `docs/releases/` with the actual `1.x` GitHub release workflow
- add `docs/releases/1.0.0.md` and `docs/releases/1.0.0-body.md` as the canonical stable release notes
- add `verify-release.mjs` and wire it into the release workflow to fail on version drift or missing release assets

## Why
The repository had drift between the documented release process and the real GitHub Actions workflow. The docs still described a manual ZIP-based release shape, while the actual release publishes flat Obsidian assets directly. The workflow also lacked a guard to stop publishing when `package.json`, `manifest.json`, `versions.json`, the tag, or the expected assets fell out of sync.

## Impact
- maintainers now have release docs that match the current `1.x` process
- release automation now validates version alignment before publishing
- release jobs now fail fast when expected assets are missing or empty

## Validation
- `npm run build`
- `npm run verify:release`
- `PROMPTFIRE_RELEASE_TAG=v1.0.0 node verify-release.mjs --require-tag`

Closes #8.
Closes #9.